### PR TITLE
Add womginx discord warning

### DIFF
--- a/views/pages/proxnav/womginx.html
+++ b/views/pages/proxnav/womginx.html
@@ -112,6 +112,7 @@
                                 </div>
                                 <p class="text-white" style="font-size: 20px; padding-top: 5px; font-family: 'Montserrat Alternates', sans-serif;">More Inf<wbr>ormation:<br></p>
                                 <p class="text-hb s-text-p2" style="font-family: Lato, sans-serif;">Has incredible support for a large amount of sites.<wbr>Works with Di<wbr>scord, Recaptcha, etc.<br><br>Many si<wbr>tes work with this.<br>This is curre<wbr>ntly one of the be<wbr>st proxi<wbr>es. Ex<wbr>plore!</p>
+                                <p class="text-hb s-text-p2" style="font-family: Lato, sans-serif;">If<wbr> you<wbr>'re exper<wbr>iencing <wbr>is<wbr>sues wi<wbr>th Recap<wbr>tcha <wbr>think<wbr>ing <wbr>you'<wbr>re<wbr> a ro<wbr>bot, us<wbr>e an<wbr>oth<wbr>pr<wbr>ox<wbr>y <wbr>UR<wbr>L.</p>
                                 <p class="text-hb s-text-p2" style="font-family: Lato, sans-serif;">Git<wbr>Hub:&nbsp;<a class="text-hb" id="wnlink"><strong>&nbsp;https://github.com/binary-person/womginx</strong></a><br></p>
                                 <p class="text-white s-text-p2"><br>Wo&#8203;mgi&#8203;nx, created by Bina&#8203;ry Per&#8203;son.</p>
                             </form>


### PR DESCRIPTION
This adds a warning to the Womginx.html page saying “If you’re having issues with Recaptcha thinking your a robot, use another proxy URL”, This goes for discord, because when registering a account Recaptcha flagged me for being a robot and thinks that people are sending automated requests.