### PR TITLE
Make IP leaking on UV not possible via CSP

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -113,6 +113,31 @@ app.register(fastifyHelmet, {
   xPoweredBy: false,
 });
 
+// change CSP on uv pages to add protection against IP leaking
+app.addHook('onRequest', (req, reply, done) => {
+  if (req.url.startsWith('/uv/service/')) {
+    reply.header('Content-Security-Policy', [
+      "default-src 'none'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "style-src-elem 'self' 'unsafe-inline'",
+      "font-src 'self'",
+      "img-src 'self'",
+      "connect-src 'self'",
+      "object-src 'none'",
+      "base-uri 'none'",
+      "form-action 'self'",
+      "worker-src 'self'",
+      "manifest-src 'self'",
+      "frame-ancestors 'none'",
+      "block-all-mixed-content",
+      "upgrade-insecure-requests"
+    ].join('; '));
+  }
+  done();
+});
+
+
 // Assign server file paths to different paths, for serving content on the website.
 app.register(fastifyStatic, {
   root: fileURLToPath(new URL('../views/pages', import.meta.url)),
@@ -347,5 +372,5 @@ app.setNotFoundHandler((req, reply) => {
   reply.code(404).type('text/html').send(preloaded404);
 });
 
-app.listen({ port: serverUrl.port, host: serverUrl.hostname });
+app.listen({ port: 7000, host: serverUrl.hostname });
 console.log(`Holy Unblocker is listening on port ${serverUrl.port}.`);


### PR DESCRIPTION
>Rewriter can get bypassed soemtimes (its not airtight)
>CSP can just block access to those things
>Profit

this is a super hacked in solution and it only works for UV but scramjet is broken rn and i dotn want to mess with it
 