### PR TITLE
feat(wisp): move backend to managed wisp-server-python 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "node": "20"
   },
-  "postCreateCommand": "npm install"
+  "postCreateCommand": "npm install && (python3 -m pip install --no-cache-dir wisp-python || pip install --no-cache-dir wisp-python || true)"
 }

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: '20.8.0'
 
+      - name: Install Wisp Python
+        run: python -m pip install --upgrade pip wisp-python
+
       - name: Install dependencies
         run: npm run fresh-install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: '20.8.0'
 
+      - name: Install Wisp Python
+        run: python3 -m pip install --upgrade pip wisp-python
+
       - name: Install dependencies
         run: npm run fresh-install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ LABEL org.opencontainers.image.title="Holy Unblocker LTS" \
       org.opencontainers.image.authors="Holy Unblocker Team" \
       org.opencontainers.image.source="https://github.com/QuiteAFancyEmerald/Holy-Unblocker/"
 
-RUN apk add --no-cache tor bash
+RUN apk add --no-cache tor bash python3 py3-pip && \
+    pip3 install --no-cache-dir wisp-python
 
 COPY . .
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ This will be our nonexhaustive todo list for Holy Unblocker LTS v6.x.x and above
 
 - [ ] Fix GeForce Now support
 - [ ] Update to use scramjetFrame instead of our own window handling
-- [ ] Implement wisp python to the project instead of the unreliable wisp-server-node
+- [x] Implement wisp python to the project instead of the unreliable wisp-server-node
 - [ ] Add booksmark menu (source wise already present pretty much)
 - [ ] Add Chii + ensuring users can access devtools while browsing - partial
 - [ ] Setting to open multiple stealth frames; basically about:blank but using our system. Pops out in another tab

--- a/config.json
+++ b/config.json
@@ -6,5 +6,17 @@
   "randomizeIdentifiers": true,
   "production": false,
   "disguiseFiles": true,
-  "usingSEO": false
+  "usingSEO": false,
+  "wispPython": {
+    "enabled": true,
+    "autostart": true,
+    "host": "127.0.0.1",
+    "port": 8070,
+    "allowLoopback": true,
+    "allowPrivate": true,
+    "blockUdp": false,
+    "logLevel": "warning",
+    "pythonPath": "",
+    "proxy": ""
+  }
 }


### PR DESCRIPTION
 (I think I did a pretty good job also sorry about the commit messages, I forgot to add the "update:" at the beginning of the message)
 1. Backend change
      - Replaced in-process @mercuryworkshop/wisp-js/server handling with a proxied, locally managed wisp-server-python.
      - src/server.mjs now:
          - Starts python -m wisp.server when enabled/autostarted.
          - Proxies upgrade requests on the Wisp path to the Python instance via TCP.
          - Handles graceful shutdown and exit signal cleanup.
          - Allows external Wisp endpoints by disabling autostart and pointing host/port to another instance.
  2. Configuration
      - New config.json -> wispPython block: enabled, autostart, host, port, allowLoopback, allowPrivate, blockUdp,
  logLevel, proxy, pythonPath.
      - Keeps client-side Wisp URL unchanged; only the backend transport swaps.
  3. Tooling & environments
      - Dockerfile installs Python 3 and wisp-python.
      - Devcontainer post-create installs wisp-python.
      - CI (Linux & Windows) installs wisp-python before build/test.
  4. Docs
      - TODO item “Implement wisp python…” marked complete.