### PR TITLE
fix: disable loopback IP access in Wisp proxy configuration

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -34,7 +34,7 @@ const wisp = new Mrrowisp({
 
   allowDirectIP: true,
   allowPrivateIPs: false,
-  allowLoopbackIPs: true,
+  allowLoopbackIPs: false,
 
   parseRealIP: true,
   trustedHeaders: ['CF-Connecting-IP', 'X-Forwarded-For'],


### PR DESCRIPTION
## Summary

The Wisp proxy configuration in `src/server.mjs` has `allowLoopbackIPs: true`, which allows any unauthenticated user connected to the proxy to route requests to `127.0.0.1` (and other loopback addresses) on the server. This is a Server-Side Request Forgery (SSRF) vulnerability (CWE-918).

## Vulnerability Details

**File:** `src/server.mjs`, line 37
**Configuration:** `allowLoopbackIPs: true` in the `Mrrowisp` constructor
**Severity:** Medium-High
**CWE:** CWE-918 (Server-Side Request Forgery)

InvisiProxy is a public-facing web proxy that requires no authentication. The Wisp protocol handler (`mrrowisp`) accepts WebSocket connections on the `/wisp` upgrade path and proxies TCP connections on behalf of clients. The `allowPrivateIPs: false` setting correctly blocks RFC1918 private ranges, but `allowLoopbackIPs: true` explicitly permits connections to `127.0.0.1`, `[::1]`, and other loopback addresses.

This means any remote user can reach services listening on localhost of the server — including any service bound to the whitelisted ports (80, 443, 9050, 7000, 7001 as configured in the `whitelistedPorts` array). Depending on what's running on the host, this could expose admin panels, databases, or other sensitive internal services.

## Proof of Concept

A client connects to the publicly exposed Wisp WebSocket endpoint and requests a TCP connection to `127.0.0.1:80`:

```javascript
// Connect to the InvisiProxy Wisp endpoint
// The WebSocket upgrade is handled at the /wisp path (src/server.mjs line 131)
import { WispConnection } from "wisp-js";

const conn = new WispConnection("wss://target-invisiproxy-instance.com/wisp/");
const stream = conn.create_stream("127.0.0.1", 80);
// stream now has a TCP connection to localhost:80 on the server
stream.send(new TextEncoder().encode("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
// Response from localhost:80 is returned to the attacker via the Wisp stream
```

No authentication is required — the proxy is public-facing and the WebSocket upgrade path has no auth gate (the `upgrade` event handler at line 130-132 routes directly to `wisp.route()` with no credential check).

## Fix

One-line change: set `allowLoopbackIPs: false`. This tells mrrowisp to reject connection requests targeting loopback addresses, matching the existing `allowPrivateIPs: false` policy for RFC1918 ranges.

```diff
-  allowLoopbackIPs: true,
+  allowLoopbackIPs: false,
```

## Testing

- Verified the change is syntactically correct and the configuration option is consistent with the existing `allowPrivateIPs: false` setting.
- After this fix, Wisp clients attempting to connect to `127.0.0.1` or `[::1]` will be rejected by mrrowisp before a TCP connection is established.
- Legitimate proxy functionality (connecting to external hosts) is unaffected.

## Adversarial Review

Before submitting, we considered whether existing mitigations prevent exploitation. The `whitelistedPorts` array restricts which destination ports are allowed, which limits the blast radius — but ports 80 and 443 on localhost are still reachable, which commonly host admin interfaces, metrics endpoints, or other sensitive services. The `allowPrivateIPs: false` setting shows the maintainer intended to block internal network access, suggesting `allowLoopbackIPs: true` is an oversight rather than an intentional design choice. The server's own console warning (line 368) explicitly mentions "loopbacks" as a security concern with certain reverse proxies, further confirming loopback access should be restricted.